### PR TITLE
Fix error (Resource already exists) when hot deploying an eclipse projec...

### DIFF
--- a/plugins/org.nuxeo.ide.sdk/src/org/nuxeo/ide/sdk/java/ProjectDeployer.java
+++ b/plugins/org.nuxeo.ide.sdk/src/org/nuxeo/ide/sdk/java/ProjectDeployer.java
@@ -89,7 +89,7 @@ public class ProjectDeployer {
         devFolder.create(IResource.FORCE|IResource.DERIVED, true, monitor);
         mainFolder.create(IResource.FORCE|IResource.DERIVED, true, monitor);
         seamFolder.create(IResource.FORCE|IResource.DERIVED, true, monitor);
-        mergeFolder(findMember(project.getOutputLocation()), mainFolder, monitor);
+        mergeOutputLocation(project.getOutputLocation(), monitor);
         for (IPackageFragmentRoot root : project.getPackageFragmentRoots()) {
             if (root.getKind() != IPackageFragmentRoot.K_SOURCE) {
                 continue;


### PR DESCRIPTION
...t whose default output folder defined in the Java Build Path is the same as the output folder of a source folder